### PR TITLE
fix: use correct data source for outgoing connections

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -233,7 +233,7 @@ export const formatConnections = (modelObject: ModelObject, incomingConnections:
 
   if (outgoingConnections.length) {
     formatString += `### Outgoing connections\n`
-    const connectionString = incomingConnections.map(c => {
+    const connectionString = outgoingConnections.map(c => {
       const connectedModel = modelObjects.find(o => o.id === c.targetId)
       if (!connectedModel) {
         return ''


### PR DESCRIPTION
## Summary

Fixes a bug in `formatConnections` where outgoing connections were iterating over `incomingConnections` instead of `outgoingConnections`.

## Problem

The `getModelObjectRelationships` tool was returning incorrect data for outgoing connections. When a user queried "what does Service A connect to?", they would see incoming connections mislabeled as outgoing.

## Solution

Changed line 236 in `src/format.ts` from:
- const connectionString = incomingConnections.map(c => {
+ const connectionString = outgoingConnections.map(c => {

Verified the fix by calling `getModelObjectRelationships` and confirming outgoing connections now display the correct source/target relationships.
