### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Dependencies
+node_modules/
+
+# Build output (will be built in container)
+dist/
+
+# Git
+.git/
+.gitignore
+
+# Environment files (secrets should be passed at runtime)
+.env
+.env.*
+!.env.example
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# Test files
+*.test.ts
+*.spec.ts
+__tests__/
+coverage/
+
+# Documentation (not needed in image)
+*.md
+!README.md
+
+# Misc
+.aider*
+*.tgz
+CODEOWNERS
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# IcePanel MCP Server Dockerfile
+# Multi-stage build for minimal production image
+
+# Stage 1: Build
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Install pnpm and dependencies
+RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN pnpm install
+
+# Copy source code
+COPY tsconfig.json ./
+COPY src/ ./src/
+COPY bin/ ./bin/
+
+# Build TypeScript
+RUN pnpm run build
+
+# Stage 2: Production
+FROM node:22-alpine AS production
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Install pnpm and production dependencies only
+RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN pnpm install --prod
+
+# Copy built files from builder stage
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/bin ./bin
+
+# Environment variables (to be provided at runtime)
+# API_KEY - Your IcePanel API key (required)
+# ORGANIZATION_ID - Your IcePanel organization ID (required)
+# ICEPANEL_API_BASE_URL - Optional API base URL override
+
+# Run the MCP server via stdio transport
+ENTRYPOINT ["node", "bin/icepanel-mcp-server.js"]
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,45 @@ Add this to your MCP Clients' MCP config file:
 }
 ```
 
+## 🐳 Docker
+
+You can also run the IcePanel MCP Server as a Docker container.
+
+### Build the Docker Image
+
+```bash
+docker build -t icepanel-mcp-server .
+```
+
+### Run with Docker
+
+```bash
+docker run -i --rm \
+  -e API_KEY="your-api-key" \
+  -e ORGANIZATION_ID="your-org-id" \
+  icepanel-mcp-server
+```
+
+### Configure MCP Client for Docker
+
+Add this to your MCP Clients' MCP config file:
+
+```json
+{
+  "mcpServers": {
+    "@icepanel/icepanel": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "API_KEY=your-api-key",
+        "-e", "ORGANIZATION_ID=your-org-id",
+        "icepanel-mcp-server"
+      ]
+    }
+  }
+}
+```
+
 ## ✉️ Support
 
 - Reach out to [Support](mailto:support@icepanel.io) if you experience any issues.


### PR DESCRIPTION
I added a simple Docker path so running the server is repeatable and easy to script.

## What I changed
- added a multi-stage Dockerfile
- added a `.dockerignore` to keep images small
- documented Docker build/run steps

## Why I did it
- local installs vary a lot, Docker keeps it consistent
- it makes demo and CI workflows easier

## Test plan
- not run

## Recommended merge order
- PR #19 (filter refactor)
- PR #20 (HTTP transport)
- PR #21 (Docker support)
- PR #22 (write tools)
- PR #23 (refactor + tests)
- PR #24 (tags + tag groups)
- PR #25 (domains)
- PR #26 (connections)
- PR #27 (diagrams)
- PR #28 (flows)
- PR #29 (model object exports)
- PR #30 (docs + tests)