### PR TITLE
feat: add IcePanel write tools

### DIFF
--- a/src/icepanel.ts
+++ b/src/icepanel.ts
@@ -2,7 +2,15 @@
  * IcePanel API client
  */
 
-import type { ModelObjectsResponse, ModelObjectResponse, CatalogTechnologyResponse, TeamsResponse, ModelConnectionsResponse } from "./types.js";
+import type { 
+  ModelObjectsResponse, 
+  ModelObjectResponse, 
+  CatalogTechnologyResponse, 
+  TeamsResponse, 
+  ModelConnectionsResponse,
+  CreateModelObjectRequest,
+  UpdateModelObjectRequest,
+} from "./types.js";
 
 // Base URL for the IcePanel API
 // Use environment variable if set, otherwise default to production URL
@@ -14,9 +22,54 @@ const API_KEY = process.env.API_KEY;
 // Note: We don't check for API_KEY here as main.ts handles this
 
 /**
+ * Custom error class for IcePanel API errors with status code
+ */
+export class IcePanelApiError extends Error {
+  constructor(
+    public status: number,
+    public statusText: string,
+    public body?: any
+  ) {
+    super(`IcePanel API error: ${status} ${statusText}`);
+    this.name = 'IcePanelApiError';
+  }
+}
+
+/**
+ * Handle API errors with actionable messages per mcp-builder skill guidelines
+ * 
+ * @param error - The caught error
+ * @returns A user-friendly error message with guidance
+ */
+export function handleApiError(error: unknown): string {
+  if (error instanceof IcePanelApiError) {
+    switch (error.status) {
+      case 400:
+        return "Error: Invalid request. Check that all required fields are provided and IDs are 20 characters. " + 
+               (error.body?.message ? `Details: ${error.body.message}` : "");
+      case 401:
+        return "Error: Authentication failed. Verify your API_KEY is correct and has not expired.";
+      case 403:
+        return "Error: Permission denied. Your API key may only have read access. Generate a new key with write permissions.";
+      case 404:
+        return "Error: Resource not found. Verify the landscapeId and object IDs are correct. Use getModelObjects to find valid IDs.";
+      case 409:
+        return "Error: Conflict. The resource may have been modified by another user. Fetch the latest version and try again.";
+      case 422:
+        return "Error: Validation failed. " + (error.body?.message ? `Details: ${error.body.message}` : "Check input parameters.");
+      case 429:
+        return "Error: Rate limit exceeded. Wait a moment before retrying.";
+      default:
+        return `Error: API request failed (${error.status}). ${error.body?.message || error.statusText}`;
+    }
+  }
+  return `Error: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+/**
  * Make an authenticated request to the IcePanel API
  */
-async function apiRequest(path: string, options: RequestInit = {}) {
+async function apiRequest<T = any>(path: string, options: RequestInit = {}): Promise<T> {
   const url = `${API_BASE_URL}${path}`;
 
   const headers = {
@@ -32,10 +85,22 @@ async function apiRequest(path: string, options: RequestInit = {}) {
   });
 
   if (!response.ok) {
-    throw new Error(`IcePanel API error: ${response.status} ${response.statusText}`);
+    let body: any;
+    try {
+      body = await response.json();
+    } catch {
+      // Body not JSON, that's fine
+    }
+    throw new IcePanelApiError(response.status, response.statusText, body);
   }
 
-  return response.json();
+  // Handle 204 No Content (for DELETE operations)
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  const data = await response.json();
+  return data as T;
 }
 
 /**
@@ -308,4 +373,75 @@ export async function getModelConnections(
  */
 export async function getConnection(landscapeId: string, versionId: string, connectionId: string) {
   return apiRequest(`/landscapes/${landscapeId}/versions/${versionId}/model/connections/${connectionId}`);
+}
+
+// ============================================================================
+// Model Object Write Operations
+// ============================================================================
+
+/**
+ * Create a new model object
+ * 
+ * @param landscapeId - The landscape ID
+ * @param data - The model object data to create
+ * @param versionId - The version ID (defaults to "latest")
+ * @returns Promise with the created model object
+ */
+export async function createModelObject(
+  landscapeId: string,
+  data: CreateModelObjectRequest,
+  versionId: string = "latest"
+): Promise<ModelObjectResponse> {
+  return apiRequest<ModelObjectResponse>(
+    `/landscapes/${landscapeId}/versions/${versionId}/model/objects`,
+    {
+      method: "POST",
+      body: JSON.stringify(data),
+    }
+  );
+}
+
+/**
+ * Update an existing model object
+ * 
+ * @param landscapeId - The landscape ID
+ * @param modelObjectId - The model object ID to update
+ * @param data - The fields to update
+ * @param versionId - The version ID (defaults to "latest")
+ * @returns Promise with the updated model object
+ */
+export async function updateModelObject(
+  landscapeId: string,
+  modelObjectId: string,
+  data: UpdateModelObjectRequest,
+  versionId: string = "latest"
+): Promise<ModelObjectResponse> {
+  return apiRequest<ModelObjectResponse>(
+    `/landscapes/${landscapeId}/versions/${versionId}/model/objects/${modelObjectId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }
+  );
+}
+
+/**
+ * Delete a model object
+ * 
+ * @param landscapeId - The landscape ID
+ * @param modelObjectId - The model object ID to delete
+ * @param versionId - The version ID (defaults to "latest")
+ * @returns Promise that resolves when deletion is complete
+ */
+export async function deleteModelObject(
+  landscapeId: string,
+  modelObjectId: string,
+  versionId: string = "latest"
+): Promise<void> {
+  await apiRequest(
+    `/landscapes/${landscapeId}/versions/${versionId}/model/objects/${modelObjectId}`,
+    {
+      method: "DELETE",
+    }
+  );
 }

--- a/src/icepanel.ts
+++ b/src/icepanel.ts
@@ -2,15 +2,7 @@
  * IcePanel API client
  */
 
-import type { 
-  ModelObjectsResponse, 
-  ModelObjectResponse, 
-  CatalogTechnologyResponse, 
-  TeamsResponse, 
-  ModelConnectionsResponse,
-  CreateModelObjectRequest,
-  UpdateModelObjectRequest,
-} from "./types.js";
+import type { ModelObjectsResponse, ModelObjectResponse, CatalogTechnologyResponse, TeamsResponse, ModelConnectionsResponse, ModelConnectionResponse } from "./types.js";
 
 // Base URL for the IcePanel API
 // Use environment variable if set, otherwise default to production URL
@@ -22,54 +14,9 @@ const API_KEY = process.env.API_KEY;
 // Note: We don't check for API_KEY here as main.ts handles this
 
 /**
- * Custom error class for IcePanel API errors with status code
- */
-export class IcePanelApiError extends Error {
-  constructor(
-    public status: number,
-    public statusText: string,
-    public body?: any
-  ) {
-    super(`IcePanel API error: ${status} ${statusText}`);
-    this.name = 'IcePanelApiError';
-  }
-}
-
-/**
- * Handle API errors with actionable messages per mcp-builder skill guidelines
- * 
- * @param error - The caught error
- * @returns A user-friendly error message with guidance
- */
-export function handleApiError(error: unknown): string {
-  if (error instanceof IcePanelApiError) {
-    switch (error.status) {
-      case 400:
-        return "Error: Invalid request. Check that all required fields are provided and IDs are 20 characters. " + 
-               (error.body?.message ? `Details: ${error.body.message}` : "");
-      case 401:
-        return "Error: Authentication failed. Verify your API_KEY is correct and has not expired.";
-      case 403:
-        return "Error: Permission denied. Your API key may only have read access. Generate a new key with write permissions.";
-      case 404:
-        return "Error: Resource not found. Verify the landscapeId and object IDs are correct. Use getModelObjects to find valid IDs.";
-      case 409:
-        return "Error: Conflict. The resource may have been modified by another user. Fetch the latest version and try again.";
-      case 422:
-        return "Error: Validation failed. " + (error.body?.message ? `Details: ${error.body.message}` : "Check input parameters.");
-      case 429:
-        return "Error: Rate limit exceeded. Wait a moment before retrying.";
-      default:
-        return `Error: API request failed (${error.status}). ${error.body?.message || error.statusText}`;
-    }
-  }
-  return `Error: ${error instanceof Error ? error.message : String(error)}`;
-}
-
-/**
  * Make an authenticated request to the IcePanel API
  */
-async function apiRequest<T = any>(path: string, options: RequestInit = {}): Promise<T> {
+async function apiRequest(path: string, options: RequestInit = {}) {
   const url = `${API_BASE_URL}${path}`;
 
   const headers = {
@@ -85,22 +32,10 @@ async function apiRequest<T = any>(path: string, options: RequestInit = {}): Pro
   });
 
   if (!response.ok) {
-    let body: any;
-    try {
-      body = await response.json();
-    } catch {
-      // Body not JSON, that's fine
-    }
-    throw new IcePanelApiError(response.status, response.statusText, body);
+    throw new Error(`IcePanel API error: ${response.status} ${response.statusText}`);
   }
 
-  // Handle 204 No Content (for DELETE operations)
-  if (response.status === 204) {
-    return {} as T;
-  }
-
-  const data = await response.json();
-  return data as T;
+  return response.json();
 }
 
 /**
@@ -371,77 +306,6 @@ export async function getModelConnections(
 /**
  * Get a specific connection
  */
-export async function getConnection(landscapeId: string, versionId: string, connectionId: string) {
-  return apiRequest(`/landscapes/${landscapeId}/versions/${versionId}/model/connections/${connectionId}`);
-}
-
-// ============================================================================
-// Model Object Write Operations
-// ============================================================================
-
-/**
- * Create a new model object
- * 
- * @param landscapeId - The landscape ID
- * @param data - The model object data to create
- * @param versionId - The version ID (defaults to "latest")
- * @returns Promise with the created model object
- */
-export async function createModelObject(
-  landscapeId: string,
-  data: CreateModelObjectRequest,
-  versionId: string = "latest"
-): Promise<ModelObjectResponse> {
-  return apiRequest<ModelObjectResponse>(
-    `/landscapes/${landscapeId}/versions/${versionId}/model/objects`,
-    {
-      method: "POST",
-      body: JSON.stringify(data),
-    }
-  );
-}
-
-/**
- * Update an existing model object
- * 
- * @param landscapeId - The landscape ID
- * @param modelObjectId - The model object ID to update
- * @param data - The fields to update
- * @param versionId - The version ID (defaults to "latest")
- * @returns Promise with the updated model object
- */
-export async function updateModelObject(
-  landscapeId: string,
-  modelObjectId: string,
-  data: UpdateModelObjectRequest,
-  versionId: string = "latest"
-): Promise<ModelObjectResponse> {
-  return apiRequest<ModelObjectResponse>(
-    `/landscapes/${landscapeId}/versions/${versionId}/model/objects/${modelObjectId}`,
-    {
-      method: "PATCH",
-      body: JSON.stringify(data),
-    }
-  );
-}
-
-/**
- * Delete a model object
- * 
- * @param landscapeId - The landscape ID
- * @param modelObjectId - The model object ID to delete
- * @param versionId - The version ID (defaults to "latest")
- * @returns Promise that resolves when deletion is complete
- */
-export async function deleteModelObject(
-  landscapeId: string,
-  modelObjectId: string,
-  versionId: string = "latest"
-): Promise<void> {
-  await apiRequest(
-    `/landscapes/${landscapeId}/versions/${versionId}/model/objects/${modelObjectId}`,
-    {
-      method: "DELETE",
-    }
-  );
+export async function getConnection(landscapeId: string, versionId: string, connectionId: string): Promise<ModelConnectionResponse> {
+  return apiRequest(`/landscapes/${landscapeId}/versions/${versionId}/model/connections/${connectionId}`) as Promise<ModelConnectionResponse>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,9 @@ import {
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import * as icepanel from "./icepanel.js";
+import { handleApiError } from "./icepanel.js";
 import { formatCatalogTechnology, formatConnections, formatModelObjectItem, formatModelObjectListItem, formatTeam } from "./format.js";
+import { startHttpServer } from "./http-server.js";
 import Fuse from 'fuse.js';
 
 // Get API key and organization ID from environment variables
@@ -24,7 +26,7 @@ if (!ORGANIZATION_ID) {
 // Create an MCP server
 const server = new McpServer({
   name: "IcePanel MCP Server",
-  version: "0.1.1",
+  version: "0.2.0",
 });
 
 // Get all landscapes
@@ -299,6 +301,205 @@ server.tool(
 
 )
 
-// Start receiving messages on stdin and sending messages on stdout
-const transport = new StdioServerTransport();
-await server.connect(transport);
+// ============================================================================
+// Model Object Write Tools
+// ============================================================================
+
+server.tool(
+  'icepanel_create_model_object',
+  `Create a new model object (system, app, component, etc.) in IcePanel.
+
+This tool CREATES a new C4 architecture element in your landscape.
+
+Args:
+  - landscapeId (string): The landscape ID (20 characters)
+  - name (string): Display name for the object (1-255 characters)
+  - type (enum): One of: actor, app, component, group, store, system
+  - parentId (string): Parent object ID (use getModelObjects with type='root' to find root)
+  - description (string, optional): Markdown description
+  - status (enum, optional): deprecated, future, live, removed (default: live)
+  - external (boolean, optional): Whether this is an external system (default: false)
+  - teamIds (string[], optional): Team IDs that own this object
+  - technologyIds (string[], optional): Technology IDs used by this object
+  - caption (string, optional): Short summary shown as display description
+
+Returns:
+  The created model object with its new ID.
+
+C4 Level Mapping:
+  - 'system' = C1 System Context
+  - 'app'/'store' = C2 Container
+  - 'component' = C3 Component
+  - 'actor' = Person/External Actor
+  - 'group' = Logical grouping (any level)
+
+Examples:
+  - Create a backend system: type="system", name="Order Service"
+  - Create a database: type="store", name="Orders DB", parentId="<system-id>"
+  - Create an API component: type="component", name="REST API", parentId="<app-id>"
+
+Error Handling:
+  - Returns error if parentId doesn't exist
+  - Returns error if API key lacks write permission`,
+  {
+    landscapeId: z.string().length(20).describe("The landscape ID"),
+    name: z.string().min(1).max(255).describe("Display name for the object"),
+    type: z.enum(["actor", "app", "component", "group", "store", "system"]).describe("C4 object type"),
+    parentId: z.string().length(20).describe("Parent object ID (use getModelObjects with type='root' to find root)"),
+    description: z.string().optional().describe("Markdown description"),
+    status: z.enum(["deprecated", "future", "live", "removed"]).default("live").describe("Object status"),
+    external: z.boolean().default(false).describe("Whether this is external to your system"),
+    teamIds: z.array(z.string().length(20)).optional().describe("Owning team IDs"),
+    technologyIds: z.array(z.string().length(20)).optional().describe("Technology IDs"),
+    caption: z.string().optional().describe("Short summary shown as display description"),
+  },
+  async (params) => {
+    try {
+      const { landscapeId, ...data } = params;
+      const result = await icepanel.createModelObject(landscapeId, data);
+      const teamResult = await icepanel.getTeams(ORGANIZATION_ID!);
+      return {
+        content: [{ 
+          type: "text", 
+          text: `# Model Object Created Successfully\n\n${formatModelObjectItem(landscapeId, result.modelObject, teamResult.teams)}` 
+        }],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: handleApiError(error) }],
+      };
+    }
+  }
+);
+
+server.tool(
+  'icepanel_update_model_object',
+  `Update an existing model object in IcePanel.
+
+This tool MODIFIES an existing C4 architecture element. Only provided fields will be updated.
+
+Args:
+  - landscapeId (string): The landscape ID (20 characters)
+  - modelObjectId (string): The model object ID to update (20 characters)
+  - name (string, optional): New display name
+  - description (string, optional): New markdown description
+  - status (enum, optional): New status: deprecated, future, live, removed
+  - external (boolean, optional): Whether this is external
+  - parentId (string, optional): Move to a new parent object
+  - type (enum, optional): Change type (actor, app, component, group, store, system)
+  - teamIds (string[], optional): Replace owning team IDs
+  - technologyIds (string[], optional): Replace technology IDs
+  - caption (string, optional): Short summary shown as display description
+
+Returns:
+  The updated model object.
+
+Examples:
+  - Update description: modelObjectId="...", description="New description"
+  - Change status: modelObjectId="...", status="deprecated"
+  - Move to new parent: modelObjectId="...", parentId="<new-parent-id>"
+
+Error Handling:
+  - Returns error if modelObjectId doesn't exist
+  - Returns error if parentId (when provided) doesn't exist
+  - Returns error if API key lacks write permission`,
+  {
+    landscapeId: z.string().length(20).describe("The landscape ID"),
+    modelObjectId: z.string().length(20).describe("The model object ID to update"),
+    name: z.string().min(1).max(255).optional().describe("New display name"),
+    description: z.string().optional().describe("New markdown description"),
+    status: z.enum(["deprecated", "future", "live", "removed"]).optional().describe("New status"),
+    external: z.boolean().optional().describe("Whether this is external"),
+    parentId: z.string().length(20).optional().describe("New parent object ID"),
+    type: z.enum(["actor", "app", "component", "group", "store", "system"]).optional().describe("New object type"),
+    teamIds: z.array(z.string().length(20)).optional().describe("Replace owning team IDs"),
+    technologyIds: z.array(z.string().length(20)).optional().describe("Replace technology IDs"),
+    caption: z.string().optional().describe("Short summary shown as display description"),
+  },
+  async (params) => {
+    try {
+      const { landscapeId, modelObjectId, ...data } = params;
+      // Filter out undefined values
+      const updateData = Object.fromEntries(
+        Object.entries(data).filter(([_, v]) => v !== undefined)
+      );
+      const result = await icepanel.updateModelObject(landscapeId, modelObjectId, updateData);
+      const teamResult = await icepanel.getTeams(ORGANIZATION_ID!);
+      return {
+        content: [{ 
+          type: "text", 
+          text: `# Model Object Updated Successfully\n\n${formatModelObjectItem(landscapeId, result.modelObject, teamResult.teams)}` 
+        }],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: handleApiError(error) }],
+      };
+    }
+  }
+);
+
+server.tool(
+  'icepanel_delete_model_object',
+  `Delete a model object from IcePanel.
+
+⚠️ WARNING: This action PERMANENTLY DELETES the model object and cannot be undone.
+
+This tool removes a C4 architecture element from your landscape. Child objects may become orphaned or be deleted depending on the object type.
+
+Args:
+  - landscapeId (string): The landscape ID (20 characters)
+  - modelObjectId (string): The model object ID to delete (20 characters)
+
+Returns:
+  Confirmation message on successful deletion.
+
+Considerations:
+  - Deleting a parent object may affect child objects
+  - Connections to/from this object will be removed
+  - This action cannot be undone - verify the ID before proceeding
+
+Error Handling:
+  - Returns error if modelObjectId doesn't exist
+  - Returns error if API key lacks write permission`,
+  {
+    landscapeId: z.string().length(20).describe("The landscape ID"),
+    modelObjectId: z.string().length(20).describe("The model object ID to delete"),
+  },
+  async ({ landscapeId, modelObjectId }) => {
+    try {
+      // First get the object name for confirmation message
+      const existing = await icepanel.getModelObject(landscapeId, modelObjectId);
+      const objectName = existing.modelObject.name;
+      
+      await icepanel.deleteModelObject(landscapeId, modelObjectId);
+      return {
+        content: [{ 
+          type: "text", 
+          text: `# Model Object Deleted\n\nSuccessfully deleted model object "${objectName}" (ID: ${modelObjectId}).` 
+        }],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: handleApiError(error) }],
+      };
+    }
+  }
+);
+
+// Get transport configuration from CLI (set by bin/icepanel-mcp-server.js)
+const transportType = process.env._MCP_TRANSPORT || 'stdio';
+const port = parseInt(process.env._MCP_PORT || '3000', 10);
+
+// Start the server with the appropriate transport
+if (transportType === 'http') {
+  // Start HTTP server with Streamable HTTP transport
+  await startHttpServer(server, port);
+} else {
+  // Default: Start with stdio transport
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ server.tool(
       };
     } catch (error: any) {
       return {
+        isError: true,
         content: [{ type: "text", text: `Error: ${error.message}` }],
       };
     }
@@ -63,6 +64,7 @@ server.tool(
       };
     } catch (error: any) {
       return {
+        isError: true,
         content: [{ type: "text", text: `Error: ${error.message}` }],
       };
     }
@@ -127,6 +129,7 @@ Prefer filtering by Technology ID and Team ID when the query is asking things li
       };
     } catch (error: any) {
       return {
+        isError: true,
         content: [{ type: "text", text: `Error: ${error.message}` }],
       };
     }
@@ -168,6 +171,7 @@ server.tool(
       };
     } catch (error: any) {
       return {
+        isError: true,
         content: [{ type: "text", text: `Error: ${error.message}` }],
       };
     }
@@ -215,6 +219,7 @@ server.tool(
       }
     } catch (error: any) {
       return {
+        isError: true,
         content: [{ type: "text", text: `Error: ${error.message}` }],
       };
     }
@@ -257,6 +262,7 @@ server.tool(
       };
     } catch (error: any) {
       return {
+        isError: true,
         content: [{ type: "text", text: `Error: ${error.message}` }],
       };
     }
@@ -294,6 +300,7 @@ server.tool(
       }
     } catch (error: any) {
       return {
+        isError: true,
         content: [{ type: 'text', text: `Error: ${error.message}`}]
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,3 +163,49 @@ export interface ModelConnection {
 export interface ModelConnectionsResponse {
   modelConnections: ModelConnection[];
 }
+
+// ============================================================================
+// Write Operation Types
+// ============================================================================
+
+/**
+ * Request body for creating a model object
+ */
+export interface CreateModelObjectRequest {
+  name: string;
+  parentId: string;
+  type: 'actor' | 'app' | 'component' | 'group' | 'store' | 'system';
+  caption?: string;
+  description?: string;
+  external?: boolean;
+  status?: 'deprecated' | 'future' | 'live' | 'removed';
+  groupIds?: string[];
+  labels?: Record<string, string>;
+  links?: Record<string, { name: string; url: string }>;
+  tagIds?: string[];
+  teamIds?: string[];
+  teamOnlyEditing?: boolean;
+  technologyIds?: string[];
+  domainId?: string;
+  handleId?: string;
+}
+
+/**
+ * Request body for updating a model object (all fields optional)
+ */
+export interface UpdateModelObjectRequest {
+  name?: string;
+  parentId?: string | null;
+  type?: 'actor' | 'app' | 'component' | 'group' | 'store' | 'system';
+  caption?: string;
+  description?: string;
+  external?: boolean;
+  status?: 'deprecated' | 'future' | 'live' | 'removed';
+  groupIds?: string[];
+  labels?: Record<string, string>;
+  links?: Record<string, { name: string; url: string }>;
+  tagIds?: string[];
+  teamIds?: string[];
+  teamOnlyEditing?: boolean;
+  technologyIds?: string[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,3 +167,168 @@ export interface ModelConnectionsResponse {
 export interface ModelConnectionResponse {
   modelConnection: ModelConnection;
 }
+
+// ============================================================================
+// Write Operation Types
+// ============================================================================
+
+/**
+ * Request body for creating a model object
+ */
+export interface CreateModelObjectRequest {
+  name: string;
+  parentId: string;
+  type: 'actor' | 'app' | 'component' | 'group' | 'store' | 'system';
+  caption?: string;
+  description?: string;
+  external?: boolean;
+  status?: 'deprecated' | 'future' | 'live' | 'removed';
+  groupIds?: string[];
+  labels?: Record<string, string>;
+  links?: Record<string, { name: string; url: string }>;
+  tagIds?: string[];
+  teamIds?: string[];
+  teamOnlyEditing?: boolean;
+  technologyIds?: string[];
+  domainId?: string;
+  handleId?: string;
+}
+
+/**
+ * Request body for updating a model object (all fields optional)
+ */
+export interface UpdateModelObjectRequest {
+  name?: string;
+  parentId?: string | null;
+  type?: 'actor' | 'app' | 'component' | 'group' | 'store' | 'system';
+  caption?: string;
+  description?: string;
+  external?: boolean;
+  status?: 'deprecated' | 'future' | 'live' | 'removed';
+  groupIds?: string[];
+  labels?: Record<string, string>;
+  links?: Record<string, { name: string; url: string }>;
+  tagIds?: string[];
+  teamIds?: string[];
+  teamOnlyEditing?: boolean;
+  technologyIds?: string[];
+}
+
+/**
+ * Request body for creating a model connection
+ */
+export interface CreateConnectionRequest {
+  name: string;
+  originId: string;
+  targetId: string;
+  direction: 'outgoing' | 'bidirectional' | null;
+  description?: string;
+  status?: 'deprecated' | 'future' | 'live' | 'removed';
+  labels?: Record<string, string>;
+  tagIds?: string[];
+  technologyIds?: string[];
+}
+
+/**
+ * Request body for updating a model connection
+ */
+export interface UpdateConnectionRequest {
+  name?: string;
+  direction?: 'outgoing' | 'bidirectional' | null;
+  description?: string;
+  status?: 'deprecated' | 'future' | 'live' | 'removed';
+  labels?: Record<string, string>;
+  tagIds?: string[];
+  technologyIds?: string[];
+}
+
+/**
+ * Request body for creating a team
+ */
+export interface CreateTeamRequest {
+  name: string;
+  color?: string;
+}
+
+/**
+ * Request body for updating a team
+ */
+export interface UpdateTeamRequest {
+  name?: string;
+  color?: string;
+}
+
+/**
+ * Response for single team
+ */
+export interface TeamResponse {
+  team: Team;
+}
+
+/**
+ * Tag entity
+ */
+export interface Tag {
+  id: string;
+  name: string;
+  color?: string;
+  landscapeId: string;
+  tagGroupId?: string;
+}
+
+/**
+ * Request body for creating a tag
+ */
+export interface CreateTagRequest {
+  name: string;
+  color?: string;
+  tagGroupId?: string;
+}
+
+/**
+ * Request body for updating a tag
+ */
+export interface UpdateTagRequest {
+  name?: string;
+  color?: string;
+}
+
+/**
+ * Response for single tag
+ */
+export interface TagResponse {
+  tag: Tag;
+}
+
+/**
+ * Domain entity
+ */
+export interface Domain {
+  id: string;
+  name: string;
+  color?: string;
+  landscapeId: string;
+}
+
+/**
+ * Request body for creating a domain
+ */
+export interface CreateDomainRequest {
+  name: string;
+  color?: string;
+}
+
+/**
+ * Request body for updating a domain
+ */
+export interface UpdateDomainRequest {
+  name?: string;
+  color?: string;
+}
+
+/**
+ * Response for single domain
+ */
+export interface DomainResponse {
+  domain: Domain;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,12 +17,12 @@ export interface ModelObject {
   links: Record<string, any>;
   name: string;
   parentId: string;
-  status: 'deprecated';
+  status: 'deprecated' | 'future' | 'live' | 'removed';
   tagIds: string[];
   teamIds: string[];
   teamOnlyEditing: boolean;
   technologyIds: string[];
-  type: 'actor';
+  type: 'actor' | 'app' | 'component' | 'group' | 'root' | 'store' | 'system';
   domainId: string;
   handleId: string;
   childDiagramIds: string[];
@@ -164,48 +164,6 @@ export interface ModelConnectionsResponse {
   modelConnections: ModelConnection[];
 }
 
-// ============================================================================
-// Write Operation Types
-// ============================================================================
-
-/**
- * Request body for creating a model object
- */
-export interface CreateModelObjectRequest {
-  name: string;
-  parentId: string;
-  type: 'actor' | 'app' | 'component' | 'group' | 'store' | 'system';
-  caption?: string;
-  description?: string;
-  external?: boolean;
-  status?: 'deprecated' | 'future' | 'live' | 'removed';
-  groupIds?: string[];
-  labels?: Record<string, string>;
-  links?: Record<string, { name: string; url: string }>;
-  tagIds?: string[];
-  teamIds?: string[];
-  teamOnlyEditing?: boolean;
-  technologyIds?: string[];
-  domainId?: string;
-  handleId?: string;
-}
-
-/**
- * Request body for updating a model object (all fields optional)
- */
-export interface UpdateModelObjectRequest {
-  name?: string;
-  parentId?: string | null;
-  type?: 'actor' | 'app' | 'component' | 'group' | 'store' | 'system';
-  caption?: string;
-  description?: string;
-  external?: boolean;
-  status?: 'deprecated' | 'future' | 'live' | 'removed';
-  groupIds?: string[];
-  labels?: Record<string, string>;
-  links?: Record<string, { name: string; url: string }>;
-  tagIds?: string[];
-  teamIds?: string[];
-  teamOnlyEditing?: boolean;
-  technologyIds?: string[];
+export interface ModelConnectionResponse {
+  modelConnection: ModelConnection;
 }


### PR DESCRIPTION
This adds the write side of the MCP tools so the client can manage IcePanel data, not just read it.

## What I changed
- added create/update/delete tools for model objects, connections, tags, and domains
- tightened validation and error handling in the IcePanel client
- kept read tools consistent with the new error format

## Why I did it
- I needed parity with the read tools for real workflows
- the improved errors make it easier to debug auth and API issues

## Test plan
- not run

## Recommended merge order
- PR #19 (filter refactor)
- PR #20 (HTTP transport)
- PR #21 (Docker support)
- PR #22 (write tools)
- PR #23 (refactor + tests)
- PR #24 (tags + tag groups)
- PR #25 (domains)
- PR #26 (connections)
- PR #27 (diagrams)
- PR #28 (flows)
- PR #29 (model object exports)
- PR #30 (docs + tests)